### PR TITLE
Add wrapper for calling openvirome lambda API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,4 +12,5 @@ dependencies = [
     "neo4j>=5.28.1",
     "psycopg2>=2.9.10",
     "pylint>=3.3.7",
+    "requests>=2.32.4",
 ]

--- a/src/resources/neo4j.py
+++ b/src/resources/neo4j.py
@@ -12,7 +12,8 @@ class Neo4jConnection:
         self._driver: Driver | None = None
         try:
             self._driver = GraphDatabase.driver(
-                self._uri, auth=(self._user, self._pwd))  # type: ignore
+                self._uri, auth=(self._user, self._pwd)
+            )  # type: ignore
         except Exception as e:
             print("Failed to create the driver:", e)
 

--- a/src/tools/openvirome.py
+++ b/src/tools/openvirome.py
@@ -1,4 +1,34 @@
+import requests
 from src.resources.psql import run_sql_query
+
+
+def post_to_openvirome_api(route: str, data: dict) -> dict:
+    """
+    Post data to the OpenVirome API.
+    Args:
+        data: The data to post.
+    Returns:
+        The response from the API.
+    """
+    valid_routes = [
+        "/identifiers",
+        "/counts",
+        "/results",
+        "/mwas",
+    ]
+    if route not in valid_routes:
+        raise ValueError(f"Invalid route: {route}. Valid routes are: {valid_routes}")
+
+    url = "https://zrdbegawce.execute-api.us-east-1.amazonaws.com/prod/" + route
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate, br, zstd",
+        "Referer": "https://mcp.openvirome.com/",
+        "Origin": "https://mcp.openvirome.com",
+    }
+    response = requests.post(url, headers=headers, json=data, timeout=300)
+    return response.json()
 
 
 def get_similar_viruses():

--- a/src/tools/workflows/register.py
+++ b/src/tools/workflows/register.py
@@ -8,4 +8,3 @@ def register_workflows(mcp):
         mcp: The FastMCP server instance
     """
     logging.info("Registering workflow tools")
-    pass

--- a/uv.lock
+++ b/uv.lock
@@ -609,6 +609,7 @@ dependencies = [
     { name = "neo4j" },
     { name = "psycopg2" },
     { name = "pylint" },
+    { name = "requests" },
 ]
 
 [package.metadata]
@@ -620,6 +621,7 @@ requires-dist = [
     { name = "neo4j", specifier = ">=5.28.1" },
     { name = "psycopg2", specifier = ">=2.9.10" },
     { name = "pylint", specifier = ">=3.3.7" },
+    { name = "requests", specifier = ">=2.32.4" },
 ]
 
 [[package]]


### PR DESCRIPTION
This function can be used for providing all responses that are used in the existing openvirome web app, i.e.:
- getting accessions matching a given set of filters
- getting counts for metadata based on applied filters
- getting paginated results for tables based on filters

We likely don't want to expose the full API and complex body args directly to LLMs and can instead provide a small set of simplified tool calls, which will be added later